### PR TITLE
update RDF commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.fcrepo</groupId>
     <artifactId>fcrepo-parent</artifactId>
-    <version>4.6.0</version>
+    <version>4.7.0</version>
   </parent>
 
   <groupId>org.fcrepo</groupId>
@@ -33,13 +33,13 @@
     <github.global.server>github</github.global.server>
 
     <!-- dependencies -->
-    <commons-rdf.version>0.2.0-incubating</commons-rdf.version>
+    <commons-rdf.version>0.3.0-incubating</commons-rdf.version>
 
     <!-- testing -->
     <jena.version>3.1.0</jena.version>
-    <junit.version>4.11</junit.version>
-    <logback.version>1.1.2</logback.version>
-    <slf4j.version>1.7.7</slf4j.version>
+    <junit.version>4.12</junit.version>
+    <logback.version>1.1.7</logback.version>
+    <slf4j.version>1.7.21</slf4j.version>
 
     <!-- osgi -->
     <osgi.export.packages>org.fcrepo.vocabulary</osgi.export.packages>

--- a/src/main/java/org/fcrepo/vocabulary/ACL.java
+++ b/src/main/java/org/fcrepo/vocabulary/ACL.java
@@ -18,8 +18,8 @@
 package org.fcrepo.vocabulary;
 
 import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.RDFTermFactory;
-import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.simple.SimpleRDF;
 
 /**
  * RDF Terms from the W3C ACL Vocabulary
@@ -27,30 +27,30 @@ import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
  */
 public class ACL {
 
-    private static RDFTermFactory factory = new SimpleRDFTermFactory();
+    private static RDF rdf = new SimpleRDF();
 
     /* Namespace */
     public static String uri = "http://www.w3.org/ns/auth/acl#";
 
     /* Classes */
-    public static IRI Access = factory.createIRI(uri + "Access");
-    public static IRI Append = factory.createIRI(uri + "Append");
-    public static IRI Authorization = factory.createIRI(uri + "Authorization");
-    public static IRI Control = factory.createIRI(uri + "Control");
-    public static IRI Read = factory.createIRI(uri + "Read");
-    public static IRI Write = factory.createIRI(uri + "Write");
+    public static IRI Access = rdf.createIRI(uri + "Access");
+    public static IRI Append = rdf.createIRI(uri + "Append");
+    public static IRI Authorization = rdf.createIRI(uri + "Authorization");
+    public static IRI Control = rdf.createIRI(uri + "Control");
+    public static IRI Read = rdf.createIRI(uri + "Read");
+    public static IRI Write = rdf.createIRI(uri + "Write");
 
     /* Properties */
-    public static IRI accessControl = factory.createIRI(uri + "accessControl");
-    public static IRI accessTo = factory.createIRI(uri + "accessTo");
-    public static IRI accessToClass = factory.createIRI(uri + "accessToClass");
-    public static IRI agent = factory.createIRI(uri + "agent");
-    public static IRI agentClass = factory.createIRI(uri + "agentClass");
-    public static IRI agentGroup = factory.createIRI(uri + "agentGroup");
-    public static IRI defaultForNew = factory.createIRI(uri + "defaultForNew");
-    public static IRI delegates = factory.createIRI(uri + "delegates");
-    public static IRI mode = factory.createIRI(uri + "mode");
-    public static IRI owner = factory.createIRI(uri + "owner");
+    public static IRI accessControl = rdf.createIRI(uri + "accessControl");
+    public static IRI accessTo = rdf.createIRI(uri + "accessTo");
+    public static IRI accessToClass = rdf.createIRI(uri + "accessToClass");
+    public static IRI agent = rdf.createIRI(uri + "agent");
+    public static IRI agentClass = rdf.createIRI(uri + "agentClass");
+    public static IRI agentGroup = rdf.createIRI(uri + "agentGroup");
+    public static IRI defaultForNew = rdf.createIRI(uri + "defaultForNew");
+    public static IRI delegates = rdf.createIRI(uri + "delegates");
+    public static IRI mode = rdf.createIRI(uri + "mode");
+    public static IRI owner = rdf.createIRI(uri + "owner");
 
     private ACL() {
         // prevent instantiation

--- a/src/main/java/org/fcrepo/vocabulary/Event.java
+++ b/src/main/java/org/fcrepo/vocabulary/Event.java
@@ -18,8 +18,8 @@
 package org.fcrepo.vocabulary;
 
 import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.RDFTermFactory;
-import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.simple.SimpleRDF;
 
 /**
  * RDF Terms from the Fedora Event Vocabulary
@@ -27,16 +27,16 @@ import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
  */
 public class Event {
 
-    private static RDFTermFactory factory = new SimpleRDFTermFactory();
+    private static RDF rdf = new SimpleRDF();
 
     /* Namespace */
     public static String uri = "http://fedora.info/definitions/v4/event#";
 
     /* Classes */
-    public static IRI ResourceCreation = factory.createIRI(uri + "ResourceCreation");
-    public static IRI ResourceDeletion = factory.createIRI(uri + "ResourceDeletion");
-    public static IRI ResourceModification = factory.createIRI(uri + "ResourceModification");
-    public static IRI ResourceRelocation = factory.createIRI(uri + "ResourceRelocation");
+    public static IRI ResourceCreation = rdf.createIRI(uri + "ResourceCreation");
+    public static IRI ResourceDeletion = rdf.createIRI(uri + "ResourceDeletion");
+    public static IRI ResourceModification = rdf.createIRI(uri + "ResourceModification");
+    public static IRI ResourceRelocation = rdf.createIRI(uri + "ResourceRelocation");
 
     private Event() {
         // prevent instantiation

--- a/src/main/java/org/fcrepo/vocabulary/Fedora.java
+++ b/src/main/java/org/fcrepo/vocabulary/Fedora.java
@@ -18,8 +18,8 @@
 package org.fcrepo.vocabulary;
 
 import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.RDFTermFactory;
-import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.simple.SimpleRDF;
 
 /**
  * RDF Terms from the Fedora Ontology
@@ -27,63 +27,63 @@ import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
  */
 public class Fedora {
 
-    private static RDFTermFactory factory = new SimpleRDFTermFactory();
+    private static RDF rdf = new SimpleRDF();
 
     /* Namespace */
     public static String uri = "http://fedora.info/definitions/v4/repository#";
 
     /* Classes */
-    public static IRI AnnotatedResource = factory.createIRI(uri + "AnnotatedResource");
-    public static IRI Binary = factory.createIRI(uri + "Binary");
-    public static IRI Configuration = factory.createIRI(uri + "Configuration");
-    public static IRI Container = factory.createIRI(uri + "Container");
-    public static IRI EmbedResources = factory.createIRI(uri + "EmbedResources");
-    public static IRI InboundReferences = factory.createIRI(uri + "InboundReferences");
-    public static IRI NonRdfSourceDescription = factory.createIRI(uri + "NonRdfSourceDescription");
-    public static IRI Pairtree = factory.createIRI(uri + "Pairtree");
-    public static IRI Relations = factory.createIRI(uri + "Relations");
-    public static IRI RepositoryRoot = factory.createIRI(uri + "RepositoryRoot");
-    public static IRI Resource = factory.createIRI(uri + "Resource");
-    public static IRI ServerManaged = factory.createIRI(uri + "ServerManaged");
-    public static IRI Skolem = factory.createIRI(uri + "Skolem");
-    public static IRI Thing = factory.createIRI(uri + "Thing");
-    public static IRI Tombstone = factory.createIRI(uri + "Tombstone");
-    public static IRI Version = factory.createIRI(uri + "Version");
+    public static IRI AnnotatedResource = rdf.createIRI(uri + "AnnotatedResource");
+    public static IRI Binary = rdf.createIRI(uri + "Binary");
+    public static IRI Configuration = rdf.createIRI(uri + "Configuration");
+    public static IRI Container = rdf.createIRI(uri + "Container");
+    public static IRI EmbedResources = rdf.createIRI(uri + "EmbedResources");
+    public static IRI InboundReferences = rdf.createIRI(uri + "InboundReferences");
+    public static IRI NonRdfSourceDescription = rdf.createIRI(uri + "NonRdfSourceDescription");
+    public static IRI Pairtree = rdf.createIRI(uri + "Pairtree");
+    public static IRI Relations = rdf.createIRI(uri + "Relations");
+    public static IRI RepositoryRoot = rdf.createIRI(uri + "RepositoryRoot");
+    public static IRI Resource = rdf.createIRI(uri + "Resource");
+    public static IRI ServerManaged = rdf.createIRI(uri + "ServerManaged");
+    public static IRI Skolem = rdf.createIRI(uri + "Skolem");
+    public static IRI Thing = rdf.createIRI(uri + "Thing");
+    public static IRI Tombstone = rdf.createIRI(uri + "Tombstone");
+    public static IRI Version = rdf.createIRI(uri + "Version");
 
     /* Named Individuals */
-    public static IRI inaccessibleResource = factory.createIRI(uri + "inaccessibleResource");
+    public static IRI inaccessibleResource = rdf.createIRI(uri + "inaccessibleResource");
 
     /* Object Properties */
-    public static IRI baseVersion = factory.createIRI(uri + "baseVersion");
-    public static IRI hasAccessRoles = factory.createIRI(uri + "hasAccessRoles");
-    public static IRI hasFixityService = factory.createIRI(uri + "hasFixityService");
-    public static IRI hasMember = factory.createIRI(uri + "hasMember");
-    public static IRI hasNamespaces = factory.createIRI(uri + "hasNamespaces");
-    public static IRI hasParent = factory.createIRI(uri + "hasParent");
-    public static IRI hasResultsMember = factory.createIRI(uri + "hasResultsMember");
-    public static IRI hasVersion = factory.createIRI(uri + "hasVersion");
-    public static IRI hasVersions = factory.createIRI(uri + "hasVersions");
-    public static IRI predecessors = factory.createIRI(uri + "predecessors");
-    public static IRI sparql = factory.createIRI(uri + "sparql");
+    public static IRI baseVersion = rdf.createIRI(uri + "baseVersion");
+    public static IRI hasAccessRoles = rdf.createIRI(uri + "hasAccessRoles");
+    public static IRI hasFixityService = rdf.createIRI(uri + "hasFixityService");
+    public static IRI hasMember = rdf.createIRI(uri + "hasMember");
+    public static IRI hasNamespaces = rdf.createIRI(uri + "hasNamespaces");
+    public static IRI hasParent = rdf.createIRI(uri + "hasParent");
+    public static IRI hasResultsMember = rdf.createIRI(uri + "hasResultsMember");
+    public static IRI hasVersion = rdf.createIRI(uri + "hasVersion");
+    public static IRI hasVersions = rdf.createIRI(uri + "hasVersions");
+    public static IRI predecessors = rdf.createIRI(uri + "predecessors");
+    public static IRI sparql = rdf.createIRI(uri + "sparql");
 
     /* Datatype Properties */
-    public static IRI computedChecksum = factory.createIRI(uri + "computedChecksum");
-    public static IRI computedSize = factory.createIRI(uri + "computedSize");
-    public static IRI created = factory.createIRI(uri + "created");
-    public static IRI createdBy = factory.createIRI(uri + "createdBy");
-    public static IRI hasLocation = factory.createIRI(uri + "hasLocation");
-    public static IRI hasMoreResults = factory.createIRI(uri + "hasMoreResults");
-    public static IRI hasTransactionProvider = factory.createIRI(uri + "hasTransactionProvider");
-    public static IRI hasVersionLabel = factory.createIRI(uri + "hasVersionLabel");
-    public static IRI isCheckedOut = factory.createIRI(uri + "isCheckedOut");
-    public static IRI lastModified = factory.createIRI(uri + "lastModified");
-    public static IRI lastModifiedBy = factory.createIRI(uri + "lastModifiedBy");
-    public static IRI numberOfChildren = factory.createIRI(uri + "numberOfChildren");
-    public static IRI numFixityErrors = factory.createIRI(uri + "numFixityErrors");
-    public static IRI numFixityRepaired = factory.createIRI(uri + "numFixityRepaired");
-    public static IRI objectCount = factory.createIRI(uri + "objectCount");
-    public static IRI objectSize = factory.createIRI(uri + "objectSize");
-    public static IRI writable = factory.createIRI(uri + "writable");
+    public static IRI computedChecksum = rdf.createIRI(uri + "computedChecksum");
+    public static IRI computedSize = rdf.createIRI(uri + "computedSize");
+    public static IRI created = rdf.createIRI(uri + "created");
+    public static IRI createdBy = rdf.createIRI(uri + "createdBy");
+    public static IRI hasLocation = rdf.createIRI(uri + "hasLocation");
+    public static IRI hasMoreResults = rdf.createIRI(uri + "hasMoreResults");
+    public static IRI hasTransactionProvider = rdf.createIRI(uri + "hasTransactionProvider");
+    public static IRI hasVersionLabel = rdf.createIRI(uri + "hasVersionLabel");
+    public static IRI isCheckedOut = rdf.createIRI(uri + "isCheckedOut");
+    public static IRI lastModified = rdf.createIRI(uri + "lastModified");
+    public static IRI lastModifiedBy = rdf.createIRI(uri + "lastModifiedBy");
+    public static IRI numberOfChildren = rdf.createIRI(uri + "numberOfChildren");
+    public static IRI numFixityErrors = rdf.createIRI(uri + "numFixityErrors");
+    public static IRI numFixityRepaired = rdf.createIRI(uri + "numFixityRepaired");
+    public static IRI objectCount = rdf.createIRI(uri + "objectCount");
+    public static IRI objectSize = rdf.createIRI(uri + "objectSize");
+    public static IRI writable = rdf.createIRI(uri + "writable");
 
     private Fedora() {
         // prevent instantiation

--- a/src/main/java/org/fcrepo/vocabulary/LDP.java
+++ b/src/main/java/org/fcrepo/vocabulary/LDP.java
@@ -18,8 +18,8 @@
 package org.fcrepo.vocabulary;
 
 import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.RDFTermFactory;
-import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.simple.SimpleRDF;
 
 /**
  * RDF Terms from the LDP Vocabulary
@@ -27,50 +27,50 @@ import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
  */
 public class LDP {
 
-    private static RDFTermFactory factory = new SimpleRDFTermFactory();
+    private static RDF rdf = new SimpleRDF();
 
     /* Namespace */
     public static String uri = "http://www.w3.org/ns/ldp#";
 
     /* Classes */
-    public static IRI BasicContainer = factory.createIRI(uri + "BasicContainer");
-    public static IRI Container = factory.createIRI(uri + "Container");
-    public static IRI DirectContainer = factory.createIRI(uri + "DirectContainer");
-    public static IRI IndirectContainer = factory.createIRI(uri + "IndirectContainer");
-    public static IRI NonRDFSource = factory.createIRI(uri + "NonRDFSource");
-    public static IRI Resource = factory.createIRI(uri + "Resource");
-    public static IRI RDFSource = factory.createIRI(uri + "RDFSource");
+    public static IRI BasicContainer = rdf.createIRI(uri + "BasicContainer");
+    public static IRI Container = rdf.createIRI(uri + "Container");
+    public static IRI DirectContainer = rdf.createIRI(uri + "DirectContainer");
+    public static IRI IndirectContainer = rdf.createIRI(uri + "IndirectContainer");
+    public static IRI NonRDFSource = rdf.createIRI(uri + "NonRDFSource");
+    public static IRI Resource = rdf.createIRI(uri + "Resource");
+    public static IRI RDFSource = rdf.createIRI(uri + "RDFSource");
 
     /* Properties */
-    public static IRI contains = factory.createIRI(uri + "contains");
-    public static IRI hasMemberRelation = factory.createIRI(uri + "hasMemberRelation");
-    public static IRI inbox = factory.createIRI(uri + "inbox");
-    public static IRI insertedContentRelation = factory.createIRI(uri + "insertedContentRelation");
-    public static IRI isMemberOfRelation = factory.createIRI(uri + "isMemberOfRelation");
-    public static IRI member = factory.createIRI(uri + "member");
-    public static IRI membershipResource = factory.createIRI(uri + "membershipResource");
+    public static IRI contains = rdf.createIRI(uri + "contains");
+    public static IRI hasMemberRelation = rdf.createIRI(uri + "hasMemberRelation");
+    public static IRI inbox = rdf.createIRI(uri + "inbox");
+    public static IRI insertedContentRelation = rdf.createIRI(uri + "insertedContentRelation");
+    public static IRI isMemberOfRelation = rdf.createIRI(uri + "isMemberOfRelation");
+    public static IRI member = rdf.createIRI(uri + "member");
+    public static IRI membershipResource = rdf.createIRI(uri + "membershipResource");
 
     /* Prefer-related Classes */
-    public static IRI PreferContainment = factory.createIRI(uri + "PreferContainment");
-    public static IRI PreferMembership = factory.createIRI(uri + "PreferMembership");
-    public static IRI PreferMinimalContainer = factory.createIRI(uri + "PreferMinimalContainer");
+    public static IRI PreferContainment = rdf.createIRI(uri + "PreferContainment");
+    public static IRI PreferMembership = rdf.createIRI(uri + "PreferMembership");
+    public static IRI PreferMinimalContainer = rdf.createIRI(uri + "PreferMinimalContainer");
 
     /* Paging Classes */
-    public static IRI PageSortCriterion = factory.createIRI(uri + "PageSortCriterion");
-    public static IRI Ascending = factory.createIRI(uri + "Ascending");
-    public static IRI Descending = factory.createIRI(uri + "Descending");
-    public static IRI Page = factory.createIRI(uri + "Page");
+    public static IRI PageSortCriterion = rdf.createIRI(uri + "PageSortCriterion");
+    public static IRI Ascending = rdf.createIRI(uri + "Ascending");
+    public static IRI Descending = rdf.createIRI(uri + "Descending");
+    public static IRI Page = rdf.createIRI(uri + "Page");
 
     /* Paging Properties */
-    public static IRI constrainedBy = factory.createIRI(uri + "constrainedBy");
-    public static IRI pageSortCriteria = factory.createIRI(uri + "pageSortCriteria");
-    public static IRI pageSortPredicate = factory.createIRI(uri + "pageSortPredicate");
-    public static IRI pageSortOrder = factory.createIRI(uri + "pageSortOrder");
-    public static IRI pageSortCollation = factory.createIRI(uri + "pageSortCollation");
-    public static IRI pageSequence = factory.createIRI(uri + "pageSequence");
+    public static IRI constrainedBy = rdf.createIRI(uri + "constrainedBy");
+    public static IRI pageSortCriteria = rdf.createIRI(uri + "pageSortCriteria");
+    public static IRI pageSortPredicate = rdf.createIRI(uri + "pageSortPredicate");
+    public static IRI pageSortOrder = rdf.createIRI(uri + "pageSortOrder");
+    public static IRI pageSortCollation = rdf.createIRI(uri + "pageSortCollation");
+    public static IRI pageSequence = rdf.createIRI(uri + "pageSequence");
 
     /* Other Classes */
-    public static IRI MemberSubject = factory.createIRI(uri + "MemberSubject");
+    public static IRI MemberSubject = rdf.createIRI(uri + "MemberSubject");
 
     private LDP() {
         // prevent instantiation

--- a/src/main/java/org/fcrepo/vocabulary/PROV.java
+++ b/src/main/java/org/fcrepo/vocabulary/PROV.java
@@ -18,8 +18,8 @@
 package org.fcrepo.vocabulary;
 
 import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.RDFTermFactory;
-import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.simple.SimpleRDF;
 
 /**
  * RDF Terms from the W3C PROV Ontology
@@ -27,101 +27,101 @@ import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
  */
 public class PROV {
 
-    private static RDFTermFactory factory = new SimpleRDFTermFactory();
+    private static RDF rdf = new SimpleRDF();
 
     /* Namespace */
     public static String uri = "http://www.w3.org/ns/prov#";
 
     /* Classes */
-    public static IRI Activity = factory.createIRI(uri + "Activity");
-    public static IRI Agent = factory.createIRI(uri + "Agent");
-    public static IRI Entity = factory.createIRI(uri + "Entity");
+    public static IRI Activity = rdf.createIRI(uri + "Activity");
+    public static IRI Agent = rdf.createIRI(uri + "Agent");
+    public static IRI Entity = rdf.createIRI(uri + "Entity");
 
     /* Expanded Classes */
-    public static IRI Bundle = factory.createIRI(uri + "Bundle");
-    public static IRI Collection = factory.createIRI(uri + "Collection");
-    public static IRI EmptyCollection = factory.createIRI(uri + "EmptyCollection");
-    public static IRI Location = factory.createIRI(uri + "Location");
-    public static IRI Organization = factory.createIRI(uri + "Organization");
-    public static IRI Person = factory.createIRI(uri + "Person");
-    public static IRI SoftwareAgent = factory.createIRI(uri + "SoftwareAgent");
+    public static IRI Bundle = rdf.createIRI(uri + "Bundle");
+    public static IRI Collection = rdf.createIRI(uri + "Collection");
+    public static IRI EmptyCollection = rdf.createIRI(uri + "EmptyCollection");
+    public static IRI Location = rdf.createIRI(uri + "Location");
+    public static IRI Organization = rdf.createIRI(uri + "Organization");
+    public static IRI Person = rdf.createIRI(uri + "Person");
+    public static IRI SoftwareAgent = rdf.createIRI(uri + "SoftwareAgent");
 
     /* Qualified Classes */
-    public static IRI ActivityInfluence = factory.createIRI(uri + "ActivityInfluence");
-    public static IRI AgentInfluence = factory.createIRI(uri + "AgentInfluence");
-    public static IRI Association = factory.createIRI(uri + "Association");
-    public static IRI Attribution = factory.createIRI(uri + "Attribution");
-    public static IRI Communication = factory.createIRI(uri + "Communication");
-    public static IRI Delegation = factory.createIRI(uri + "Delegation");
-    public static IRI Derivation = factory.createIRI(uri + "Derivation");
-    public static IRI End = factory.createIRI(uri + "End");
-    public static IRI EntityInfluence = factory.createIRI(uri + "EntityInfluence");
-    public static IRI Generation = factory.createIRI(uri + "Generation");
-    public static IRI Influence = factory.createIRI(uri + "Influence");
-    public static IRI InstantaneousEvent = factory.createIRI(uri + "InstantaneousEvent");
-    public static IRI Invalidation = factory.createIRI(uri + "Invalidation");
-    public static IRI Plan = factory.createIRI(uri + "Plan");
-    public static IRI PrimarySource = factory.createIRI(uri + "PrimarySource");
-    public static IRI Quotation = factory.createIRI(uri + "Quotation");
-    public static IRI Revision = factory.createIRI(uri + "Revision");
-    public static IRI Start = factory.createIRI(uri + "Start");
-    public static IRI Usage = factory.createIRI(uri + "Usage");
+    public static IRI ActivityInfluence = rdf.createIRI(uri + "ActivityInfluence");
+    public static IRI AgentInfluence = rdf.createIRI(uri + "AgentInfluence");
+    public static IRI Association = rdf.createIRI(uri + "Association");
+    public static IRI Attribution = rdf.createIRI(uri + "Attribution");
+    public static IRI Communication = rdf.createIRI(uri + "Communication");
+    public static IRI Delegation = rdf.createIRI(uri + "Delegation");
+    public static IRI Derivation = rdf.createIRI(uri + "Derivation");
+    public static IRI End = rdf.createIRI(uri + "End");
+    public static IRI EntityInfluence = rdf.createIRI(uri + "EntityInfluence");
+    public static IRI Generation = rdf.createIRI(uri + "Generation");
+    public static IRI Influence = rdf.createIRI(uri + "Influence");
+    public static IRI InstantaneousEvent = rdf.createIRI(uri + "InstantaneousEvent");
+    public static IRI Invalidation = rdf.createIRI(uri + "Invalidation");
+    public static IRI Plan = rdf.createIRI(uri + "Plan");
+    public static IRI PrimarySource = rdf.createIRI(uri + "PrimarySource");
+    public static IRI Quotation = rdf.createIRI(uri + "Quotation");
+    public static IRI Revision = rdf.createIRI(uri + "Revision");
+    public static IRI Start = rdf.createIRI(uri + "Start");
+    public static IRI Usage = rdf.createIRI(uri + "Usage");
 
     /* Properties */
-    public static IRI actedOnBehalfOf = factory.createIRI(uri + "actedOnBehalfOf");
-    public static IRI endedAtTime = factory.createIRI(uri + "endedAtTime");
-    public static IRI startedAtTime = factory.createIRI(uri + "startedAtTime");
-    public static IRI used = factory.createIRI(uri + "used");
-    public static IRI wasAssociatedWith = factory.createIRI(uri + "wasAssociatedWith");
-    public static IRI wasAttributedTo = factory.createIRI(uri + "wasAttributedTo");
-    public static IRI wasDerivedFrom = factory.createIRI(uri + "wasDerivedFrom");
-    public static IRI wasGeneratedBy = factory.createIRI(uri + "wasGeneratedBy");
-    public static IRI wasInformedBy = factory.createIRI(uri + "wasInformedBy");
+    public static IRI actedOnBehalfOf = rdf.createIRI(uri + "actedOnBehalfOf");
+    public static IRI endedAtTime = rdf.createIRI(uri + "endedAtTime");
+    public static IRI startedAtTime = rdf.createIRI(uri + "startedAtTime");
+    public static IRI used = rdf.createIRI(uri + "used");
+    public static IRI wasAssociatedWith = rdf.createIRI(uri + "wasAssociatedWith");
+    public static IRI wasAttributedTo = rdf.createIRI(uri + "wasAttributedTo");
+    public static IRI wasDerivedFrom = rdf.createIRI(uri + "wasDerivedFrom");
+    public static IRI wasGeneratedBy = rdf.createIRI(uri + "wasGeneratedBy");
+    public static IRI wasInformedBy = rdf.createIRI(uri + "wasInformedBy");
 
     /* Expanded Properties */
-    public static IRI alternateOf = factory.createIRI(uri + "alternateOf");
-    public static IRI atLocation = factory.createIRI(uri + "atLocation");
-    public static IRI generated = factory.createIRI(uri + "generated");
-    public static IRI generatedAtTime = factory.createIRI(uri + "generatedAtTime");
-    public static IRI hadMember = factory.createIRI(uri + "hadMember");
-    public static IRI hadPrimarySource = factory.createIRI(uri + "hadPrimarySource");
-    public static IRI influenced = factory.createIRI(uri + "influenced");
-    public static IRI invalidated = factory.createIRI(uri + "invalidated");
-    public static IRI invalidatedAtTime = factory.createIRI(uri + "invalidatedAtTime");
-    public static IRI specializationOf = factory.createIRI(uri + "specializationOf");
-    public static IRI value = factory.createIRI(uri + "value");
-    public static IRI wasEndedBy = factory.createIRI(uri + "wasEndedBy");
-    public static IRI wasInvalidatedBy = factory.createIRI(uri + "wasInvalidatedBy");
-    public static IRI wasQuotedFrom = factory.createIRI(uri + "wasQuotedFrom");
-    public static IRI wasRevisionOf = factory.createIRI(uri + "wasRevisionOf");
-    public static IRI wasStartedBy = factory.createIRI(uri + "wasStartedBy");
+    public static IRI alternateOf = rdf.createIRI(uri + "alternateOf");
+    public static IRI atLocation = rdf.createIRI(uri + "atLocation");
+    public static IRI generated = rdf.createIRI(uri + "generated");
+    public static IRI generatedAtTime = rdf.createIRI(uri + "generatedAtTime");
+    public static IRI hadMember = rdf.createIRI(uri + "hadMember");
+    public static IRI hadPrimarySource = rdf.createIRI(uri + "hadPrimarySource");
+    public static IRI influenced = rdf.createIRI(uri + "influenced");
+    public static IRI invalidated = rdf.createIRI(uri + "invalidated");
+    public static IRI invalidatedAtTime = rdf.createIRI(uri + "invalidatedAtTime");
+    public static IRI specializationOf = rdf.createIRI(uri + "specializationOf");
+    public static IRI value = rdf.createIRI(uri + "value");
+    public static IRI wasEndedBy = rdf.createIRI(uri + "wasEndedBy");
+    public static IRI wasInvalidatedBy = rdf.createIRI(uri + "wasInvalidatedBy");
+    public static IRI wasQuotedFrom = rdf.createIRI(uri + "wasQuotedFrom");
+    public static IRI wasRevisionOf = rdf.createIRI(uri + "wasRevisionOf");
+    public static IRI wasStartedBy = rdf.createIRI(uri + "wasStartedBy");
 
     /* Qualified Properties */
-    public static IRI activity = factory.createIRI(uri + "activity");
-    public static IRI agent = factory.createIRI(uri + "agent");
-    public static IRI atTime = factory.createIRI(uri + "atTime");
-    public static IRI entity = factory.createIRI(uri + "entity");
-    public static IRI hadActivity = factory.createIRI(uri + "hadActivity");
-    public static IRI hadGeneration = factory.createIRI(uri + "hadGeneration");
-    public static IRI hadPlan = factory.createIRI(uri + "hadPlan");
-    public static IRI hadRole = factory.createIRI(uri + "hadRole");
-    public static IRI hadUsage = factory.createIRI(uri + "hadUsage");
-    public static IRI influencer = factory.createIRI(uri + "influencer");
-    public static IRI qualifiedAssociation = factory.createIRI(uri + "qualifiedAssociation");
-    public static IRI qualifiedAttribution = factory.createIRI(uri + "qualifiedAttribution");
-    public static IRI qualifiedCommunication = factory.createIRI(uri + "qualifiedCommunication");
-    public static IRI qualifiedDelegation = factory.createIRI(uri + "qualifiedDelegation");
-    public static IRI qualifiedDerivation = factory.createIRI(uri + "qualifiedDerivation");
-    public static IRI qualifiedEnd = factory.createIRI(uri + "qualifiedEnd");
-    public static IRI qualifiedGeneration = factory.createIRI(uri + "qualifiedGeneration");
-    public static IRI qualifiedInfluence = factory.createIRI(uri + "qualifiedInfluence");
-    public static IRI qualifiedInvalidation = factory.createIRI(uri + "qualifiedInvalidation");
-    public static IRI qualifiedPrimarySource = factory.createIRI(uri + "qualifiedPrimarySource");
-    public static IRI qualifiedQuotation = factory.createIRI(uri + "qualifiedQuotation");
-    public static IRI qualifiedRevision = factory.createIRI(uri + "qualifiedRevision");
-    public static IRI qualifiedStart = factory.createIRI(uri + "qualifiedStart");
-    public static IRI qualifiedUsage = factory.createIRI(uri + "qualifiedUsage");
-    public static IRI wasInfluencedBy = factory.createIRI(uri + "wasInfluencedBy");
+    public static IRI activity = rdf.createIRI(uri + "activity");
+    public static IRI agent = rdf.createIRI(uri + "agent");
+    public static IRI atTime = rdf.createIRI(uri + "atTime");
+    public static IRI entity = rdf.createIRI(uri + "entity");
+    public static IRI hadActivity = rdf.createIRI(uri + "hadActivity");
+    public static IRI hadGeneration = rdf.createIRI(uri + "hadGeneration");
+    public static IRI hadPlan = rdf.createIRI(uri + "hadPlan");
+    public static IRI hadRole = rdf.createIRI(uri + "hadRole");
+    public static IRI hadUsage = rdf.createIRI(uri + "hadUsage");
+    public static IRI influencer = rdf.createIRI(uri + "influencer");
+    public static IRI qualifiedAssociation = rdf.createIRI(uri + "qualifiedAssociation");
+    public static IRI qualifiedAttribution = rdf.createIRI(uri + "qualifiedAttribution");
+    public static IRI qualifiedCommunication = rdf.createIRI(uri + "qualifiedCommunication");
+    public static IRI qualifiedDelegation = rdf.createIRI(uri + "qualifiedDelegation");
+    public static IRI qualifiedDerivation = rdf.createIRI(uri + "qualifiedDerivation");
+    public static IRI qualifiedEnd = rdf.createIRI(uri + "qualifiedEnd");
+    public static IRI qualifiedGeneration = rdf.createIRI(uri + "qualifiedGeneration");
+    public static IRI qualifiedInfluence = rdf.createIRI(uri + "qualifiedInfluence");
+    public static IRI qualifiedInvalidation = rdf.createIRI(uri + "qualifiedInvalidation");
+    public static IRI qualifiedPrimarySource = rdf.createIRI(uri + "qualifiedPrimarySource");
+    public static IRI qualifiedQuotation = rdf.createIRI(uri + "qualifiedQuotation");
+    public static IRI qualifiedRevision = rdf.createIRI(uri + "qualifiedRevision");
+    public static IRI qualifiedStart = rdf.createIRI(uri + "qualifiedStart");
+    public static IRI qualifiedUsage = rdf.createIRI(uri + "qualifiedUsage");
+    public static IRI wasInfluencedBy = rdf.createIRI(uri + "wasInfluencedBy");
 
     private PROV() {
         // prevent instantiation

--- a/src/main/java/org/fcrepo/vocabulary/WebAC.java
+++ b/src/main/java/org/fcrepo/vocabulary/WebAC.java
@@ -18,8 +18,8 @@
 package org.fcrepo.vocabulary;
 
 import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.RDFTermFactory;
-import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
+import org.apache.commons.rdf.api.RDF;
+import org.apache.commons.rdf.simple.SimpleRDF;
 
 /**
  * RDF Terms from the Fedora WebAC Vocabulary
@@ -27,13 +27,13 @@ import org.apache.commons.rdf.simple.SimpleRDFTermFactory;
  */
 public class WebAC {
 
-    private static RDFTermFactory factory = new SimpleRDFTermFactory();
+    private static RDF rdf = new SimpleRDF();
 
     /* Namespace */
     public static String uri = "http://fedora.info/definitions/v4/webac#";
 
     /* Classes */
-    public static IRI Acl = factory.createIRI(uri + "Acl");
+    public static IRI Acl = rdf.createIRI(uri + "Acl");
 
     private WebAC() {
         // prevent instantiation


### PR DESCRIPTION
This updates the use of commons-rdf to use the new `RDF` interface that is new with version 0.3.0.

The jena dependency is _not_ updated, as it leads to test failures in fetching the Fedora vocabularies (it may relate to how those vocabularies are published).