### PR TITLE
Update initial version snapshot to 0.1.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.fcrepo</groupId>
   <artifactId>fcrepo-vocabulary</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <name>Fedora Commons RDF Vocabularies</name>
   <description>RDF Vocabularies in use by Fedora Commons</description>
   <url>http://fedorarepository.org</url>


### PR DESCRIPTION
http://semver.org/ recommends using 0.1.0 as an initial release; so this increments the current snapshot to be in line with that recommendation.